### PR TITLE
Add Tron-Legacy to supported themes list

### DIFF
--- a/README.org
+++ b/README.org
@@ -417,6 +417,7 @@
    - [[https://github.com/belak/base16-emacs][Base16]]
    - [[https://github.com/hlissner/emacs-doom-themes][Doom Themes]]
    - [[https://github.com/ogdenwebb/emacs-kaolin-themes][Kaolin Themes]]
+   - [[https://github.com/ianpan870102/tron-legacy-emacs-theme][Tron Legacy]]
    - [[https://github.com/ianpan870102/wilmersdorf-emacs-theme][Wilmsersdorf Theme]]
    - [[https://github.com/bbatsov/zenburn-emacs][Zenburn]]
 ** Sent Pull Request


### PR DESCRIPTION
Hi Emmanuel! 

I've added support for centaur tabs in my tron-legacy theme. Here's a screenshot for your reference:

<img width="1919" alt="screenshot2-tron copy" src="https://user-images.githubusercontent.com/36686900/61940752-ac447b80-afc8-11e9-8bd2-1406ffec7e37.png">
