### PR TITLE
add variables for icon height and vertical alignment

### DIFF
--- a/centaur-tabs.el
+++ b/centaur-tabs.el
@@ -136,6 +136,14 @@
     map)
   "Keymap used for setting mouse events for a tab.")
 
+(defvar centaur-tabs-icon-scale-factor
+  1.0
+  "The base scale factor for the `height' face property of tab icons.")
+
+(defvar centaur-tabs-icon-v-adjust
+  0.01
+  "The vertical adjust for tab icons.")
+
 ;;; Customs
 ;;
 (defcustom centaur-tabs-cycle-scope nil
@@ -607,8 +615,11 @@ If icon gray out option enabled, gray out icon if not SELECTED."
 			 (all-the-icons-auto-mode-match?))
 		    (all-the-icons-icon-for-file
 		     (file-name-nondirectory (buffer-file-name))
-		     :v-adjust 0.01)
-		  (all-the-icons-icon-for-mode major-mode :v-adjust 0.01)))
+		     :v-adjust centaur-tabs-icon-v-adjust
+             :height centaur-tabs-icon-scale-factor)
+		  (all-the-icons-icon-for-mode major-mode
+                                       :v-adjust centaur-tabs-icon-v-adjust
+                                       :height centaur-tabs-icon-scale-factor)))
 	       (background (face-background face))
 	       (inactive (if (and (not selected)
 				  (eq centaur-tabs-gray-out-icons 'buffer))


### PR DESCRIPTION
Hi,

I think this might be helpful. I once changed font size in tabs but found the icons remains big as before. These two variables may help people like me tune their tabs looking.

Thanks.