### PR TITLE
Fix centaur-tabs-active-bar-face in README

### DIFF
--- a/README.org
+++ b/README.org
@@ -137,7 +137,7 @@
    #+END_SRC
    [[./images/overline.png]]
 
-   The color can be customized via the centaur-active-bar-face face.
+   The color can be customized via the centaur-tabs-active-bar-face face.
 ** Customize the close button
    To disable the close button
    #+BEGIN_SRC emacs-lisp :tangle yes


### PR DESCRIPTION
There is incorrect face `centaur-active-bar-face` in README, it should be corrected to `centaur-tabs-active-bar-face`.