### PR TITLE
bugfix Support selecting tab with more-than-2-keystrokes sequence

### DIFF
--- a/centaur-tabs.el
+++ b/centaur-tabs.el
@@ -2046,7 +2046,7 @@ not the actual logical index position of the current group."
 	 (key (make-vector 1 event))
 	 (key-desc (key-description key)))
     (centaur-tabs-select-visible-nth-tab
-     (string-to-number (nth 1 (split-string key-desc "-"))))))
+     (string-to-number (car (last (split-string key-desc "-")))))))
 
 ;;;;;;;;;;;;;;;;;;;;;;; Utils functions ;;;;;;;;;;;;;;;;;;;;;;;
 (defun centaur-tabs-get-groups ()


### PR DESCRIPTION
The centaur-tabs-select-visible-tab() function assumes it will
be bound to key sequences with 2 keystrokes only. It selects the
2nd element of the key sequence and treats it as the tab number.

To support key sequences more than 2 keystrokes, changed to
select the last element of the key sequence as the tab number.