### PR TITLE
Remove for/backward button messages

### DIFF
--- a/centaur-tabs.el
+++ b/centaur-tabs.el
@@ -1063,7 +1063,6 @@ Depend on the setting of the option `centaur-tabs-cycle-scope'."
 (defun centaur-tabs-backward--button (event)
   "Same as centaur-tabs-backward, but changing window to EVENT source."
   (interactive "e")
-  (message "backward button")
   (select-window (posn-window (event-start event)))
   (centaur-tabs-backward))
 
@@ -1071,7 +1070,6 @@ Depend on the setting of the option `centaur-tabs-cycle-scope'."
 (defun centaur-tabs-forward--button (event)
   "Same as centaur-tabs-forward, but changing window to EVENT source."
   (interactive "e")
-  (message "forward button")
   (select-window (posn-window (event-start event)))
   (centaur-tabs-forward))
 


### PR DESCRIPTION
They don't seem to be needed, since the mouse over messages,
describe what they do, and when they are clicked then a visible
action occurs.

They also added an entry to the messages buffer
every time the next or previous buttons were clicked.

They might just have been there for development logging.

---

These variables might be useful for future projects.
```elisp

;; Show a message in the minibuffer,
;; but not in the messages buffer.
(global-set-key (kbd "<f8>")
                #'(lambda () (interactive)
                    (let (message-log-max)
                      (message (format-time-string
                                "%Y-%m-%dT%H:%M:%S")))))

;; Show a message in the messages buffer,
;; but not in the minibuffer.
(global-set-key (kbd "<f9>")
                #'(lambda () (interactive)
                    (let ((inhibit-message t))
                      (message (format-time-string
                                "%Y-%m-%dT%H:%M:%S")))))

;; the message-log-max variable is describe here:
https://www.gnu.org/software/emacs/manual/html_node/elisp/Logging-Messages.html

;; the inihibit-message variable is described here:
https://www.gnu.org/software/emacs/manual/html_node/elisp/Displaying-Messages.html
```
