### PR TITLE
Reorder tabs with navigation buttons and CTRL key.

### DIFF
--- a/README.org
+++ b/README.org
@@ -353,7 +353,7 @@
    - Click the mouse wheel to close a buffer.
    - Right click on any part of the header line (tabs or empty space) to show a tab groups popup.
    - Use the mouse wheel to invoke ~centaur-tabs-backward/forward~.
-   - Set the =centaur-tabs-show-navigation-buttons= customizable variable to =t= to display cool navigation buttons.
+   - Set the =centaur-tabs-show-navigation-buttons= customizable variable to =t= to display cool navigation buttons. With the CTRL key, navigation buttons will reorder tabs.
    [[file:images/navigation-buttons.png]]
 * TO DO [17/19]
   - [X] Integrate all-the-icons

--- a/centaur-tabs-functions.el
+++ b/centaur-tabs-functions.el
@@ -217,6 +217,7 @@ When not specified, ELLIPSIS defaults to ‘...’."
   (let ((map (make-sparse-keymap)))
     (define-key map (vector centaur-tabs-display-line 'mouse-1) 'centaur-tabs-backward--button)
     (define-key map (vector centaur-tabs-display-line 'mouse-3) 'centaur-tabs--groups-menu)
+    (define-key map (vector centaur-tabs-display-line 'C-mouse-1) 'centaur-tabs-move-current-tab-to-left--button)
     map)
   "Keymap used for setting mouse events for backward tab button.")
 
@@ -224,6 +225,7 @@ When not specified, ELLIPSIS defaults to ‘...’."
   (let ((map (make-sparse-keymap)))
     (define-key map (vector centaur-tabs-display-line 'mouse-1) 'centaur-tabs-forward--button)
     (define-key map (vector centaur-tabs-display-line 'mouse-3) 'centaur-tabs--groups-menu)
+    (define-key map (vector centaur-tabs-display-line 'C-mouse-1) 'centaur-tabs-move-current-tab-to-right--button)
     map)
   "Keymap used for setting mouse events for forward tab button.")
 
@@ -278,6 +280,29 @@ When not specified, ELLIPSIS defaults to ‘...’."
   (interactive "e")
   (select-window (posn-window (event-start event)))
   (centaur-tabs-forward))
+
+(defun centaur-tabs-move-current-tab-to-left--button (evt)
+  "Same as centaur-tabs-move-current-tab-to-left, but ensuring the tab will remain visible.  The active window will the the EVT source."
+  (interactive "e")
+  (centaur-tabs-move-current-tab-to-left)
+  (centaur-tabs--button-ensure-selected-tab-is-visible evt))
+
+
+(defun centaur-tabs-move-current-tab-to-right--button (evt)
+  "Same as centaur-tabs-move-current-tab-to-right, but ensuring the tab will remain visible.  The active window will the the EVT source."
+  (interactive "e")
+  (centaur-tabs-move-current-tab-to-right)
+  (centaur-tabs--button-ensure-selected-tab-is-visible evt))
+
+(defun centaur-tabs--button-ensure-selected-tab-is-visible (evt)
+  "This is a nasty trick to make the current tab visible, since centaur-tabs--track-selected or centaur-tabs-auto-scroll-flag seems not to work.  EVT is used to change the active window."
+  ;;; This works if the tab has not reached the last position
+  (centaur-tabs-forward--button evt)
+  (centaur-tabs-backward--button evt)
+  ;;; Just in case the tab has the tab reached the last position
+  (centaur-tabs-backward--button evt)
+  (centaur-tabs-forward--button evt))
+
 
 ;;; Tab and tab sets
 ;;


### PR DESCRIPTION
Reorder tabs with navigation buttons and CTRL key.

If you activate `centaur-tabs-show-navigation-buttons`, clicking on a button move the tab (`centaur-tabs-move-current-tab-to-left` or `centaur-tabs-move-current-tab-to-right`)

I still have a problem:  The function `centaur-tabs--button-ensure-selected-tab-is-visible` is a little bit ugly, and `centaur-tabs--track-selected` and `centaur-tabs-auto-scroll-flag` seems not to work. Do you know how to solve this?