### PR TITLE
Frame-local visualization (improves daemon mode usability)

### DIFF
--- a/centaur-tabs-elements.el
+++ b/centaur-tabs-elements.el
@@ -194,9 +194,9 @@ If icon gray out option enabled, gray out icon if not SELECTED."
 			       (centaur-tabs-plain-icons
 				(face-foreground 'centaur-tabs-selected))
 			       (t 'unspecified)))
-	       (underline (and (eq centaur-tabs-set-bar 'under)
+	       (underline (and (eq (if (display-graphic-p) centaur-tabs-set-bar) 'under)
 			       (face-attribute face :underline)))
-	       (overline (and (eq centaur-tabs-set-bar 'over)
+	       (overline (and (eq (if (display-graphic-p) centaur-tabs-set-bar) 'over)
 			      (face-attribute face :overline))))
 	  (if (stringp icon)
 	      (progn

--- a/centaur-tabs-functions.el
+++ b/centaur-tabs-functions.el
@@ -423,14 +423,14 @@ That is, remove it from the tab sets store."
   (cl-mapcar 'centaur-tabs-tab-value (centaur-tabs-tabs tabset)))
 
 (defun centaur-tabs-get-cache (cache key)
-  "Return the per-frame cached value of KEY in CACHE"
+  "Return the per-frame cached value of KEY in CACHE."
   (let
       ((cached-hash (frame-parameter nil cache)))
     (if (hash-table-p cached-hash)
 	(gethash key cached-hash nil))))
 
 (defun centaur-tabs-put-cache (cache key value)
-  "Set the per-frame cached value of KEY in CACHE to VALUE"
+  "Set the per-frame cached value of KEY in CACHE to VALUE."
   (let*
       ((cached-hash (frame-parameter nil cache))
        (hash (if (hash-table-p cached-hash) cached-hash (make-hash-table))))

--- a/centaur-tabs.el
+++ b/centaur-tabs.el
@@ -188,11 +188,6 @@ Run as `centaur-tabs-init-hook'."
     (set-face-attribute 'centaur-tabs-unselected-modified nil
 			:overline nil
 			:underline nil))
-  (unless (display-graphic-p)
-    (setq
-     centaur-tabs-set-icons nil
-     centaur-tabs-show-navigation-buttons nil
-     centaur-tabs-set-bar nil))
   (add-hook 'after-save-hook #'centaur-tabs-on-saving-buffer)
   (add-hook 'first-change-hook #'centaur-tabs-on-modifying-buffer)
   (add-hook 'kill-buffer-hook #'centaur-tabs-buffer-track-killed)


### PR DESCRIPTION
- Check for display capability as needed (so each connected frame gets
the correct frame-specific value)
- Use a frame-local cache for tabsets instead of a global one