### PR TITLE
Key binding bug

### DIFF
--- a/centaur-tabs-functions.el
+++ b/centaur-tabs-functions.el
@@ -193,7 +193,7 @@ When not specified, ELLIPSIS defaults to ‘...’."
     (define-key km [(control up)]    'centaur-tabs-backward-group)
     (define-key km [(control down)]  'centaur-tabs-forward-group)
     (define-key km [(control f10)]   'centaur-tabs-local-mode)
-    (define-key km [(control 5)]   'centaur-tabs-extract-window-to-new-frame)
+    (define-key km (kbd "C-5")     'centaur-tabs-extract-window-to-new-frame)
     (define-key km [(control k)]   'centaur-tabs-kill-other-buffers-in-current-group)
     (define-key km [(control o)]   'centaur-tabs-open-in-external-application)
     (define-key km [(control d)]   'centaur-tabs-open-directory-in-external-application)


### PR DESCRIPTION
centaur-tabs-extract-window-to-new-frame had [(control 5)]  as key binding in centaur-tabs-prefix-map.

Unfortunately, [(control 5)] translates to "C-e" instead of "C-5", that seems the intended keybinding. Also, "C-c C-e" is used in org-mode and latex-mode, so It provokes a conflict.

Changed [(control 5)] to (kbd "C-5").