### PR TITLE
Add support for a "new tab" button

### DIFF
--- a/README.org
+++ b/README.org
@@ -35,6 +35,7 @@
   - [[#ivy-integration][Ivy integration]]
   - [[#projectile-integration][Projectile integration]]
   - [[#mouse-support-thanks-to-alvarogonzalezsotillo][Mouse support (thanks to alvarogonzalezsotillo)]]
+  - [[#new-tab-button-thanks-to-lucasgruss][New-tab button (thanks to lucasgruss)]]
   - [[#key-bindings][Key bindings]]
 - [[#to-do-1719][TO DO]]
 - [[#my-personal-configuration][My personal configuration]]
@@ -387,6 +388,20 @@
    - Use the mouse wheel to invoke ~centaur-tabs-backward/forward~.
    - Set the =centaur-tabs-show-navigation-buttons= custom variable to =t= to display cool navigation buttons. With the CTRL key, the left and right navigation buttons will move the tabs through the tab line.
      [[file:images/navigation-buttons.png]]
+** New-tab button (thanks to lucasgruss)
+   The new-tab button is a button at the right of the tabs that will spawn a new
+   tab based on the current context. For instance in
+   ~vterm/eshell/ansi-term~ mode, the new tab will spawn a new buffer
+   corresponding to the current major mode. In ~eww~, you are prompted for a
+   search term and the result is displayed in a new buffer. The default
+   behaviour in other modes is to open a new empty buffer.
+
+   - the variable ~centaur-tabs-show-new-tab-button~ controls whether the button
+     is shown.
+   - the variable ~centaur-tabs-new-tab-text~ controls the appearance of the button.
+   - the function ~centaur-tabs--create-new-tab~ controls the behaviour of the
+     context-based new tab.
+
 ** Key bindings
    If you want to enable a series of key bindings with different tab managing functions, put the following in your configuration before the package is loaded (if you use =use-package=, this should go in the =:init= section):
    #+BEGIN_SRC emacs-lisp

--- a/centaur-tabs-elements.el
+++ b/centaur-tabs-elements.el
@@ -317,7 +317,7 @@ Taken from `doom-modeline'."
 
 ;;; New tab button
 ;;
-(defcustom centaur-tabs-show-new-tab-button nil
+(defcustom centaur-tabs-show-new-tab-button t
   "When non-nil, show the button to create a new tab."
   :group 'centaur-tabs
   :type 'boolean)

--- a/centaur-tabs-elements.el
+++ b/centaur-tabs-elements.el
@@ -315,6 +315,11 @@ Taken from `doom-modeline'."
   :group 'centaur-tabs
   :type 'string)
 
+(defcustom centaur-tabs-new-tab-text " + "
+  "Text icon to show in the down button tab."
+  :group 'centaur-tabs
+  :type 'string)
+
 ;;; Separators
 ;;
 (defvar centaur-tabs-style-left nil)

--- a/centaur-tabs-elements.el
+++ b/centaur-tabs-elements.el
@@ -315,6 +315,13 @@ Taken from `doom-modeline'."
   :group 'centaur-tabs
   :type 'string)
 
+;;; New tab button
+;;
+(defcustom centaur-tabs-show-new-tab-button nil
+  "When non-nil, show the button to create a new tab."
+  :group 'centaur-tabs
+  :type 'boolean)
+
 (defcustom centaur-tabs-new-tab-text " + "
   "Text icon to show in the down button tab."
   :group 'centaur-tabs

--- a/centaur-tabs-elements.el
+++ b/centaur-tabs-elements.el
@@ -323,7 +323,7 @@ Taken from `doom-modeline'."
   :type 'boolean)
 
 (defcustom centaur-tabs-new-tab-text " + "
-  "Text icon to show in the down button tab."
+  "Text icon to show in the new-tab button."
   :group 'centaur-tabs
   :type 'string)
 

--- a/centaur-tabs-functions.el
+++ b/centaur-tabs-functions.el
@@ -257,6 +257,12 @@ When not specified, ELLIPSIS defaults to ‘...’."
     map)
   "Keymap used for setting mouse events for a tab.")
 
+(defvar centaur-tabs-new-tab-map
+  (let ((map (make-sparse-keymap)))
+    (define-key map (vector centaur-tabs-display-line 'mouse-1) 'centaur-tabs--create-new-tab)
+    map)
+  "Keymap used for setting mouse events for new tab button.")
+
 ;;; Events and event functions
 ;;
 (defun centaur-tabs-buffer-close-tab (tab)
@@ -769,7 +775,8 @@ template element."
       (nreverse elts)
       (propertize "% "
                   'face (list :background padcolor)
-                  'pointer 'arrow)))
+                  'pointer 'arrow)
+      (centaur-tabs-line-format--new-button)))
     ))
 
 (defun centaur-tabs-line-format--buttons ()
@@ -786,6 +793,15 @@ template element."
                    'local-map centaur-tabs-forward-tab-map
                    'help-echo "Next tab"))
     ""))
+
+(defun centaur-tabs-line-format--new-button ()
+  "Return the buttons fragment of the header line."
+  (if centaur-tabs-show-navigation-buttons
+      (concat
+       (propertize (centaur-tabs-button-tab centaur-tabs-new-tab-text)
+                   'local-map centaur-tabs-new-tab-map
+                   'help-echo "Create new tab")
+    "")))
 
 (defun centaur-tabs-line ()
   "Return the header line templates that represent the tab bar.
@@ -1234,6 +1250,19 @@ Other buffer group by `centaur-tabs-get-group-name' with project name."
      "OrgMode")
     (t
      (centaur-tabs-get-group-name (current-buffer))))))
+
+(defun centaur-tabs--create-new-tab ()
+  "Create a new tab"
+  (interactive)
+  (cond
+   ((string= exwm-class-name "Firefox-esr")
+            (start-process "firefox" nil "firefox"))
+   ((eq major-mode 'exwm)
+          (call-interactively #'app-laucher-run-app))
+   ((eq major-mode 'vterm-mode)
+    (vterm))
+   (t
+    (call-interactively #'find-file))))
 
 (defun centaur-tabs-hide-tab (x)
   "Do no to show buffer X in tabs."

--- a/centaur-tabs-functions.el
+++ b/centaur-tabs-functions.el
@@ -1252,7 +1252,7 @@ Other buffer group by `centaur-tabs-get-group-name' with project name."
      (centaur-tabs-get-group-name (current-buffer))))))
 
 (defun centaur-tabs--create-new-tab ()
-  "Create a new tab"
+  "Create a context-aware new tab."
   (interactive)
   (cond
    ((eq major-mode 'vterm-mode)

--- a/centaur-tabs-functions.el
+++ b/centaur-tabs-functions.el
@@ -259,7 +259,7 @@ When not specified, ELLIPSIS defaults to ‘...’."
 
 (defvar centaur-tabs-new-tab-map
   (let ((map (make-sparse-keymap)))
-    (define-key map (vector centaur-tabs-display-line 'mouse-1) 'centaur-tabs--create-new-tab)
+    (define-key map (vector centaur-tabs-display-line 'mouse-1) 'centaur-tabs-new-tab--button)
     map)
   "Keymap used for setting mouse events for new tab button.")
 
@@ -313,6 +313,11 @@ When not specified, ELLIPSIS defaults to ‘...’."
   (interactive "e")
   (select-window (posn-window (event-start event)))
   (centaur-tabs-forward))
+
+(defun centaur-tabs-create-new-tab--button (event)
+  (interactive "e")
+  (select-window (posn-window (event-start event)))
+  (centaur-tabs--create-new-tab))
 
 (defun centaur-tabs-move-current-tab-to-left--button (evt)
   "Same as centaur-tabs-move-current-tab-to-left, but ensuring the tab will remain visible.  The active window will the the EVT source."

--- a/centaur-tabs-functions.el
+++ b/centaur-tabs-functions.el
@@ -1261,11 +1261,11 @@ Other buffer group by `centaur-tabs-get-group-name' with project name."
   (interactive)
   (cond
    ((eq major-mode 'eshell-mode)
-    (eshell))
+    (eshell t))
    ((eq major-mode 'vterm-mode)
     (vterm))
    ((eq major-mode 'term-mode)
-    (ansi-term))
+    (ansi-term "/bin/bash"))
    ((derived-mode-p 'eww-mode)
     (let ((current-prefix-arg 4))
       (call-interactively #'eww)))

--- a/centaur-tabs-functions.el
+++ b/centaur-tabs-functions.el
@@ -795,7 +795,8 @@ template element."
     ""))
 
 (defun centaur-tabs-line-format--new-button ()
-  "Return the buttons fragment of the header line."
+  "Return the new-tab button fragment at the right end of the
+header line."
   (if centaur-tabs-show-new-tab-button
       (concat
        (propertize (centaur-tabs-button-tab centaur-tabs-new-tab-text)

--- a/centaur-tabs-functions.el
+++ b/centaur-tabs-functions.el
@@ -796,7 +796,7 @@ template element."
 
 (defun centaur-tabs-line-format--new-button ()
   "Return the buttons fragment of the header line."
-  (if centaur-tabs-show-navigation-buttons
+  (if centaur-tabs-show-new-tab-button
       (concat
        (propertize (centaur-tabs-button-tab centaur-tabs-new-tab-text)
                    'local-map centaur-tabs-new-tab-map

--- a/centaur-tabs-functions.el
+++ b/centaur-tabs-functions.el
@@ -307,14 +307,13 @@ When not specified, ELLIPSIS defaults to ‘...’."
   (select-window (posn-window (event-start event)))
   (centaur-tabs-backward))
 
-
 (defun centaur-tabs-forward--button (event)
   "Same as centaur-tabs-forward, but changing window to EVENT source."
   (interactive "e")
   (select-window (posn-window (event-start event)))
   (centaur-tabs-forward))
 
-(defun centaur-tabs-create-new-tab--button (event)
+(defun centaur-tabs-new-tab--button (event)
   (interactive "e")
   (select-window (posn-window (event-start event)))
   (centaur-tabs--create-new-tab))

--- a/centaur-tabs-functions.el
+++ b/centaur-tabs-functions.el
@@ -1255,12 +1255,10 @@ Other buffer group by `centaur-tabs-get-group-name' with project name."
   "Create a new tab"
   (interactive)
   (cond
-   ((string= exwm-class-name "Firefox-esr")
-            (start-process "firefox" nil "firefox"))
-   ((eq major-mode 'exwm)
-          (call-interactively #'app-laucher-run-app))
    ((eq major-mode 'vterm-mode)
     (vterm))
+   ((eq major-mode 'term-mode)
+    (ansi-term))
    (t
     (call-interactively #'find-file))))
 

--- a/centaur-tabs-functions.el
+++ b/centaur-tabs-functions.el
@@ -1255,10 +1255,15 @@ Other buffer group by `centaur-tabs-get-group-name' with project name."
   "Create a context-aware new tab."
   (interactive)
   (cond
+   ((eq major-mode 'eshell-mode)
+    (eshell))
    ((eq major-mode 'vterm-mode)
     (vterm))
    ((eq major-mode 'term-mode)
     (ansi-term))
+   ((derived-mode-p 'eww-mode)
+    (let ((current-prefix-arg 4))
+      (call-interactively #'eww)))
    (t
     (call-interactively #'find-file))))
 


### PR DESCRIPTION
Hi ! 
In my usage of centaur tabs in EXWM (to manage my firefox tabs) I felt like the package could use a "new tab" button at the right of the tab-line. This has given me the idea of this "new tab" button, that is context aware (based on the major mode in the current buffer).

New configuration options:
 - `centaur-tabs-show-new-tab-button` : whether to show or hide this button
 - `centaur-tabs-new-tab-text` : content of the button (" + " by default)
 
 New function :
- `centaur-tabs--create-new-tab` : defines the behaviour of the "new tab" button, based on the context. Here, if the button is pressed in a eww buffer, user is prompted for a search term and the result is displayed in a new buffer. If in vterm/term/shell mode, a new buffer with the same mode is opened.

I hope you find this to be a useful addition to centaur-tabs !

