### PR TITLE
Enable use of completing-read, not ido-completing-read, in centaur-tabs

### DIFF
--- a/README.org
+++ b/README.org
@@ -1,10 +1,10 @@
 #+TITLE: Centaur tabs
 #+CREATOR: Emmanuel Bustos T.
-#+OPTIONS: toc:nil 
+#+OPTIONS: toc:nil
 
-  [[https://melpa.org/#/centaur-tabs][file:https://melpa.org/packages/centaur-tabs-badge.svg]] 
+  [[https://melpa.org/#/centaur-tabs][file:https://melpa.org/packages/centaur-tabs-badge.svg]]
   [[https://stable.melpa.org/#/centaur-tabs][file:https://stable.melpa.org/packages/centaur-tabs-badge.svg]]
-  [[http://www.gnu.org/licenses/gpl-3.0][file:https://img.shields.io/badge/License-GPL%20v3-blue.svg]] 
+  [[http://www.gnu.org/licenses/gpl-3.0][file:https://img.shields.io/badge/License-GPL%20v3-blue.svg]]
 
   [[./images/centaur.png]]
 * Contents                                                              :TOC:
@@ -45,7 +45,7 @@
 * IMPORTANT
   Now =centaur-tabs= supports Emacs 27's native =tab-line= and it uses it to render the tabs. Previously the tabs were rendered in the =header-line=. Although Emacs 27's tab-line workspaces are not yet supported, the feature will be implemented in a near future.
 * What is this?
-  This projects aims to become an aesthetic, functional and efficient tabs plugin for Emacs with a lot of customization options. 
+  This projects aims to become an aesthetic, functional and efficient tabs plugin for Emacs with a lot of customization options.
   Although this is a fork from [[https://github.com/manateelazycat/awesome-tab][awesome-tab]] (that I forked with the permission from the author and it's also based on [[https://github.com/dholm/tabbar][tabbar]]) it's been heavily modified so now it may be considered a different package.
   Also this package integrates functionalities from [[https://github.com/mattfidler/tabbar-ruler.el][tabbar-ruler]].
 
@@ -53,7 +53,7 @@
 
   [[./screenshot.png]]
 * Installation
-  You can download this package from MELPA. This is a basic ~use-package~ configuration: 
+  You can download this package from MELPA. This is a basic ~use-package~ configuration:
   #+BEGIN_SRC emacs-lisp :tangle yes
     (use-package centaur-tabs
       :demand
@@ -75,7 +75,7 @@
 * Customization
   This package is heavily customizable, with many options available to the user. Here are some of them:
 ** Headline face
-   You can make the headline face match the centaur-tabs-default face. This makes the tabbar have an uniform appearance. In your configuration use the following function: 
+   You can make the headline face match the centaur-tabs-default face. This makes the tabbar have an uniform appearance. In your configuration use the following function:
    #+BEGIN_SRC emacs-lisp :tangle yes
      (centaur-tabs-headline-match)
    #+END_SRC
@@ -117,7 +117,7 @@
    - "zigzag"
 
   [[./images/zigzag.png]]
-  
+
 ** Tab height
    To change the tab height do
    #+BEGIN_SRC emacs-lisp :tangle yes
@@ -144,7 +144,7 @@
     (setq centaur-tabs-set-bar 'left)
    #+END_SRC
    [[./images/bar.png]]
-   
+
    To display an overline over the selected tab:
    #+BEGIN_SRC emacs-lisp :tangle yes
     (setq centaur-tabs-set-bar 'over)
@@ -159,7 +159,7 @@
     (setq x-underline-at-descent-line t)
    #+END_SRC
    [[./images/underline.png]]
-   
+
    The color can be customized via the centaur-tabs-active-bar-face face.
 ** Customize the close button
    To disable the close button
@@ -193,7 +193,7 @@
    #+BEGIN_SRC emacs-lisp :tangle yes
      (add-hook 'dired-mode-hook 'centaur-tabs-local-mode)
    #+END_SRC
-   
+
    or with ~use-package~:
    #+BEGIN_SRC emacs-lisp :tangle yes
      (use-package centaur-tabs
@@ -204,7 +204,7 @@
    #+END_SRC
 
 ** Buffer groups
-   To customize the way that the buffers are grouped modify the ~centaur-tabs-buffer-groups~ function like this: 
+   To customize the way that the buffers are grouped modify the ~centaur-tabs-buffer-groups~ function like this:
    #+BEGIN_SRC emacs-lisp :tangle yes
      (defun centaur-tabs-buffer-groups ()
        "`centaur-tabs-buffer-groups' control buffers' group rules.
@@ -245,20 +245,20 @@
 	 (t
 	  (centaur-tabs-get-group-name (current-buffer))))))
    #+END_SRC
-   
-** Show buffer groups names instead of buffer names in tabs 
+
+** Show buffer groups names instead of buffer names in tabs
    If you want your tabs to display buffer groups names instead of buffer names you can put the following in your configuration:
    #+BEGIN_SRC emacs-lisp :tangle yes
      (setq centaur-tabs--buffer-show-groups t)
    #+END_SRC
-   You can toggle between the two options interactively with the ~(centaur-tabs-toggle-groups)~ command. 
+   You can toggle between the two options interactively with the ~(centaur-tabs-toggle-groups)~ command.
 ** Enable Vim like tab motions
    To enable Vim like tab changing binds
    #+BEGIN_SRC emacs-lisp :tangle yes
      (define-key evil-normal-state-map (kbd "g t") 'centaur-tabs-forward)
      (define-key evil-normal-state-map (kbd "g T") 'centaur-tabs-backward)
    #+END_SRC
-   
+
    or with ~use-package~:
    #+BEGIN_SRC emacs-lisp :tangle yes
      (use-package centaur-tabs
@@ -269,7 +269,7 @@
 	     ("g T" . centaur-tabs-backward))
        ...)
    #+END_SRC
-** Prevent the access to specified buffers 
+** Prevent the access to specified buffers
    You can prevent the access to some buffers via tab motions changing the following function like this:
    #+BEGIN_SRC emacs-lisp :tangle yes
 (defun centaur-tabs-hide-tab (x)
@@ -300,13 +300,13 @@
 	  (not (file-name-extension name)))
      )))
      #+END_SRC
-     The function shown is the default function from the =centaur-tabs= configuration, adding the =(string-prefix-p "*​mybuf" name)= part to prevent the access to every buffer with its name ending in "mybuf". You can either add this function as it is to preserve =centaur-tabs= default filters and add any Boolean function that you want to filter your buffers (i.e =string-prefix-p= or =string-suffix-p=) like in this example with the "mybuf" line, or completely override the function with your custom filters if you completely know what you're doing. 
+     The function shown is the default function from the =centaur-tabs= configuration, adding the =(string-prefix-p "*​mybuf" name)= part to prevent the access to every buffer with its name ending in "mybuf". You can either add this function as it is to preserve =centaur-tabs= default filters and add any Boolean function that you want to filter your buffers (i.e =string-prefix-p= or =string-suffix-p=) like in this example with the "mybuf" line, or completely override the function with your custom filters if you completely know what you're doing.
 ** Tab cycling
    The default behaviour from the ~centaur-tabs-forward/backward~ functions is to go through all the tabs in the current group and then change the group. If this is something that is to desired to be changed the ~centaur-tabs-cycle-scope~ custom must be changed like this:
    #+BEGIN_SRC emacs-lisp :tangle yes
      (setq centaur-tabs-cycle-scope 'tabs)
    #+END_SRC
-   
+
    There are three options:
    - 'default: (Already described)
    - 'tabs: Cycle through visible tabs (that is, the tabs in the current group)
@@ -328,21 +328,21 @@
      ;; Move the currently selected tab to the right of the the last visited tab.
      (setq centaur-tabs-adjust-buffer-order 'right)
    #+END_SRC
-   
+
    This works the following way. If there's a certain group of tabs like the following:
-   
+
    |tab1.el | tab2.js | tab3.c | tab4.py |
-   
+
    If you're in a tab and change to another tab in the group (via Ido, Ivy or Helm) the new tab will move to the right side of the tab you were, so if you're on ~tab1.el~ and you clicked ~tab4.py~ the tabs order will be the following:
-   
+
    | tab1.el | tab4.py | tab2.js | tab3.c |
- 
+
    And then if you were on ~tab4.py~ and changed to ~tab2.js~, the tabs order will be the following:
 
    | tab1.el | tab4.py | tab2.js | tab3.c |
 
    the order doesn't change, because the tabs are already next to each other.
-   
+
    And now if you were on ~tab2.js~ and changed to ~tab1.el~, the tabs order will be the following:
    | tab4.py | tab1.el | tab2.js | tab3.c |
 
@@ -357,13 +357,15 @@
    NOTE: Given the Emacs behaviour when opening a new file is a little bit funky, when a new tab is opened, it will always be placed at the right of the last visited buffer. This behaviour needs to be investigated in order to see if a possible solution exists.
 ** Fixed tab length
    If you desire to make the width of your tabs fixed, you have to modify the ~centaur-tabs-label-fixed-length~ custom variable with the maximum length desired (defaults to 0 for dynamic). Example:
-   #+BEGIN_SRC emacs-lisp :tangle yes 
+   #+BEGIN_SRC emacs-lisp :tangle yes
      (setq centaur-tabs-label-fixed-length 8)
    #+END_SRC
    Would render the following tabs:
 
    |foo.org|a_very_d...|bar.org|
 
+** [[https://github.com/raxod502/selectrum][Selectrum]] integration (revert to ~completing-read~)
+   Turn off default ~ido-mode~ completions by customising ~centaur-tabs-enable-ido-completion~ in order to revert to Emacs' native ~completing-read~.
 ** Helm integration
    You can integrate Helm with centaur-tabs for changing tab-groups. Just add helm-source-centaur-tabs-group in helm-source-list. Then you'll be able to use ~(centaur-tabs-build-helm-source)~ function and bind it to any key you want. (I'm not a Helm user so I'll not be able to solve problems related to this).
 ** Ivy integration
@@ -373,7 +375,7 @@
    #+BEGIN_SRC emacs-lisp :tangle yes
      (centaur-tabs-group-by-projectile-project)
    #+END_SRC
-   
+
    This function can be called interactively to enable Projectile grouping. To go back to centaur-tabs's user defined (or default) buffer grouping function you can interactively call:
    #+BEGIN_SRC emacs-lisp :tangle yes
      (centaur-tabs-group-buffer-groups)
@@ -407,12 +409,12 @@
   - [X] Improve all the icons placing
   - [X] Fix all the icons background
   - [X] Add selected, unselected, selected-modified and unselected-modified faces
-  - [X] Make function to inherit tabbar faces 
+  - [X] Make function to inherit tabbar faces
   - [X] Group tabs by projectile's project (was already implemented but not for projectile)
-  - [X] Create PR to different theme packages for this package 
+  - [X] Create PR to different theme packages for this package
   - [X] Add modified marker icon option
   - [X] Add sideline for selected tab (atom style)
-  - [X] Add overline for selected tab (atom style). It's easy to add to the text, but not to the icon, so for any who figures it out a PR is welcome. 
+  - [X] Add overline for selected tab (atom style). It's easy to add to the text, but not to the icon, so for any who figures it out a PR is welcome.
   - [ ] Add easy tab style configuration function. (Atom, Sublime, VS Code... like ~(centaur-tabs-tab-theme "atom")~)
   - [X] Make icon insert after the separator
   - [X] Add a customizable close button
@@ -420,12 +422,12 @@
   - [X] Fix messages buffer icon an FontAwesome errors
   - [X] Check for Elscreen compatibility
   - [X] Add this package to MELPA
-  - [X] Make a configuration to display buffer groups names instead of buffer names in tabs 
-  - [ ] Add full evil-mode support with tab commands 
-    
-* My personal configuration 
+  - [X] Make a configuration to display buffer groups names instead of buffer names in tabs
+  - [ ] Add full evil-mode support with tab commands
+
+* My personal configuration
   My personal configuration for reference:
-  
+
 #+BEGIN_SRC emacs-lisp :tangle yes
   (use-package centaur-tabs
     :load-path "~/.emacs.d/other/centaur-tabs"
@@ -525,5 +527,3 @@
 * How to contribute
   You can contribute by forking the repo and then creating a pull request with the changes you consider will improve the package. There's a TO DO list with wanted features so you can start from there. I'll be glad to receive help.
   Please try to keep the code as clear and documented as possible.
-  
-  

--- a/centaur-tabs-functions.el
+++ b/centaur-tabs-functions.el
@@ -1294,7 +1294,7 @@ Operates over buffer BUF"
     extension-names))
 
 (defcustom centaur-tabs-enable-ido-completion t
-  "non-nil means use `ido-completing-read' for completing reads else `completing-read'."
+  "Non-nil means use `ido-completing-read' for completing reads else `completing-read'."
   :group 'centaur-tabs
   :type 'boolean)
 

--- a/centaur-tabs-functions.el
+++ b/centaur-tabs-functions.el
@@ -1294,12 +1294,13 @@ Operates over buffer BUF"
     extension-names))
 
 (defcustom centaur-tabs-enable-ido-completion t
-  "use ido-completing-read for completing reads else completing-read"
+  "non-nil means use `ido-completing-read' for completing reads else `completing-read'."
   :group 'centaur-tabs
   :type 'boolean)
 
 (defun centaur-tabs-completing-read (prompt choices)
-  "select an option using a completing read"
+  "Prompt user with PROMPT to select from CHOICES using a completing read.
+Refer to  the variable `centaur-tabs-enable-ido-completion'."
   (interactive)
   (if centaur-tabs-enable-ido-completion
       (ido-completing-read prompt choices)

--- a/centaur-tabs-functions.el
+++ b/centaur-tabs-functions.el
@@ -1299,7 +1299,7 @@ Operates over buffer BUF"
   :type 'boolean)
 
 (defun centaur-completing-read (prompt choices)
-  "select a completing read"
+  "select an option using a completing read"
   (interactive)
   (if centaur-tabs-enable-ido-completion
       (ido-completing-read prompt choices)

--- a/centaur-tabs-functions.el
+++ b/centaur-tabs-functions.el
@@ -1293,6 +1293,18 @@ Operates over buffer BUF"
 	  (buffer-list))
     extension-names))
 
+(defcustom centaur-tabs-enable-ido-completion t
+  "use ido-completing-read for completing reads else completing-read"
+  :group 'centaur-tabs
+  :type 'boolean)
+
+(defun centaur-completing-read (prompt choices)
+  "select a completing read"
+  (interactive)
+  (if centaur-tabs-enable-ido-completion
+      (ido-completing-read prompt choices)
+    (completing-read prompt choices)))
+
 ;;;;;;;;;;;;;;;;;;;;;;; Default configurations ;;;;;;;;;;;;;;;;;;;;;;;
 
 (mapc (lambda (hook)

--- a/centaur-tabs-functions.el
+++ b/centaur-tabs-functions.el
@@ -1298,7 +1298,7 @@ Operates over buffer BUF"
   :group 'centaur-tabs
   :type 'boolean)
 
-(defun centaur-completing-read (prompt choices)
+(defun centaur-tabs-completing-read (prompt choices)
   "select an option using a completing read"
   (interactive)
   (if centaur-tabs-enable-ido-completion

--- a/centaur-tabs-interactive.el
+++ b/centaur-tabs-interactive.el
@@ -40,7 +40,7 @@
 				       (funcall centaur-tabs-buffer-groups-function) )))
 			   (funcall centaur-tabs-buffer-list-function)))
 	 (groups (centaur-tabs-get-groups))
-	 (group-name (or groupname (centaur-completing-read "Groups: " groups))) )
+	 (group-name (or groupname (centaur-tabs-completing-read "Groups: " groups))) )
     (catch 'done
       (mapc
        #'(lambda (group)
@@ -190,7 +190,7 @@ Optional argument REVERSED default is move backward, if reversed is non-nil move
 	 (extension-names (centaur-tabs-get-extensions))
 	 match-extension)
     ;; Read extension need to kill.
-    (setq match-extension (centaur-completing-read "Kill buffers suffix with: " extension-names))
+    (setq match-extension (centaur-tabs-completing-read "Kill buffers suffix with: " extension-names))
     ;; Kill all buffers match extension in current group.
     (centaur-tabs-kill-buffer-match-rule
      (lambda (buffer)
@@ -209,7 +209,7 @@ Optional argument REVERSED default is move backward, if reversed is non-nil move
 	 (extension-names (centaur-tabs-get-extensions))
 	 match-extension)
     ;; Read extension need to kill.
-    (setq match-extension (centaur-completing-read "Just keep buffers suffix with: " extension-names))
+    (setq match-extension (centaur-tabs-completing-read "Just keep buffers suffix with: " extension-names))
     ;; Kill all buffers match extension in current group.
     (centaur-tabs-kill-buffer-match-rule
      (lambda (buffer)

--- a/centaur-tabs-interactive.el
+++ b/centaur-tabs-interactive.el
@@ -28,6 +28,7 @@
 (require 'centaur-tabs-elements)
 (require 'centaur-tabs-functions)
 ;;;;;;;;;;;;;;;;;;;;;;; Interactive functions ;;;;;;;;;;;;;;;;;;;;;;;
+
 (defun centaur-tabs-switch-group (&optional groupname)
   "Switch tab groups using ido.  GROUPNAME can optionaly be provided."
   (interactive)
@@ -39,7 +40,7 @@
 				       (funcall centaur-tabs-buffer-groups-function) )))
 			   (funcall centaur-tabs-buffer-list-function)))
 	 (groups (centaur-tabs-get-groups))
-	 (group-name (or groupname (ido-completing-read "Groups: " groups))) )
+	 (group-name (or groupname (centaur-completing-read "Groups: " groups))) )
     (catch 'done
       (mapc
        #'(lambda (group)
@@ -189,7 +190,7 @@ Optional argument REVERSED default is move backward, if reversed is non-nil move
 	 (extension-names (centaur-tabs-get-extensions))
 	 match-extension)
     ;; Read extension need to kill.
-    (setq match-extension (ido-completing-read "Kill buffers suffix with: " extension-names))
+    (setq match-extension (centaur-completing-read "Kill buffers suffix with: " extension-names))
     ;; Kill all buffers match extension in current group.
     (centaur-tabs-kill-buffer-match-rule
      (lambda (buffer)
@@ -208,7 +209,7 @@ Optional argument REVERSED default is move backward, if reversed is non-nil move
 	 (extension-names (centaur-tabs-get-extensions))
 	 match-extension)
     ;; Read extension need to kill.
-    (setq match-extension (ido-completing-read "Just keep buffers suffix with: " extension-names))
+    (setq match-extension (centaur-completing-read "Just keep buffers suffix with: " extension-names))
     ;; Kill all buffers match extension in current group.
     (centaur-tabs-kill-buffer-match-rule
      (lambda (buffer)
@@ -331,7 +332,7 @@ Should be buffer local and speed up calculation of buffer groups.")
     (let ((buffer (current-buffer)))
       (delete-window)
       (display-buffer-pop-up-frame buffer nil))))
-      
+
 (defun centaur-tabs--copy-file-name-to-clipboard ()
   "Copy the current buffer file name to the clipboard."
   ;;; From https://emacsredux.com/blog/2013/03/27/copy-filename-to-the-clipboard/
@@ -460,11 +461,11 @@ Modified copy of `treemacs-visit-node-in-external-application`."
 
     (when (not click-on-tab-p)
       (centaur-tabs--groups-menu))
-    
+
     (when click-on-tab-p
       (centaur-tabs-do-select event)
       (redisplay t)
-      
+
       (let*
 	  ((menu (easy-menu-create-menu nil (centaur-tabs--tab-menu-definition)))
 	   (choice (x-popup-menu t menu))


### PR DESCRIPTION
Added `centaur-tabs-enable-ido-completion` defaults to t, leaving current behaviour the same. Toggling it off reverts to `completing-read ` thus facilitating other mechanisms which plug into completing-read like [selectrum](https://github.com/raxod502/selectrum).