### PR TITLE
Add centaur-tabs-local-mode-if-enabled

### DIFF
--- a/centaur-tabs.el
+++ b/centaur-tabs.el
@@ -114,6 +114,13 @@ hidden, it is shown again.  Signal an error if Centaur-Tabs mode is off."
       ;; The tab bar is locally hidden, show it again.
       (kill-local-variable centaur-tabs-display-line-format))))
 
+(defun centaur-tabs-local-mode-if-enabled ()
+  "Enable `centaur-tabs-local-mode' if `centaur-tabs-mode' is on.
+Can safely be used in hooks without erroring-out in case that
+`centaur-tabs-mode' is disabled."
+  (when centaur-tabs-mode
+    (centaur-tabs-local-mode)))
+
 ;;; Centaur-Tabs mode
 ;;
 (defvar centaur-tabs--global-hlf nil)


### PR DESCRIPTION
I am still experimenting with `centaur-tabs-mode` and found that the `centair-tabs-local-mode` hook from the README was a bit too invasive: when I turn `(centaur-tabs-mode -1)` off, then the local minor mode would error out. That resulted in my org agenda not displaying at all :)

My suggestion would be to add one of the following:

1. to offer a function in the library that doesn't error out (this PR)
2. to offer this function in the README example instead of the main lib
3. to change the minor mode and just do nothing instead of erroring-out (would be my favorite to be honest, but not sure if this is intentional)

@ema2159 @nebhrajani-a  What would you think is the best approach? Happy to amend the PR accordingly