### PR TITLE
Add centaur-tabs-show-tab-index

### DIFF
--- a/README.org
+++ b/README.org
@@ -137,6 +137,11 @@
    #+BEGIN_SRC emacs-lisp :tangle yes
     (setq centaur-tabs-gray-out-icons 'buffer)
    #+END_SRC
+** Displaying an index
+   To display an index in the tabs:
+   #+BEGIN_SRC emacs-lisp :tangle yes
+    (setq centaur-tabs-show-tab-index t)
+   #+END_SRC
 ** Selected tab bar
    To display a colored bar at the left of the selected tab
    #+BEGIN_SRC emacs-lisp :tangle yes

--- a/centaur-tabs-elements.el
+++ b/centaur-tabs-elements.el
@@ -321,6 +321,11 @@ Taken from `doom-modeline'."
   :group 'centaur-tabs
   :type 'boolean)
 
+(defcustom centaur-tabs-show-tab-index nil
+  "Non-nil to display index in tab."
+  :group 'centaurs-tabs
+  :type 'boolean)
+
 ;;; New tab button
 ;;
 (defcustom centaur-tabs-show-new-tab-button t

--- a/centaur-tabs-functions.el
+++ b/centaur-tabs-functions.el
@@ -85,6 +85,11 @@ visible."
   :type '(repeat symbol)
   :group 'centaur-tabs)
 
+(defcustom centaur-tabs-index-format-str "[%d] "
+  "Format string for tab index."
+  :group 'centaur-tabs
+  :type 'string)
+
 (defvar centaur-tabs-hide-tab-function 'centaur-tabs-hide-tab
   "Function to hide tabs.
 This function filters tabs.  The tab will hide if this function returns t.")
@@ -596,10 +601,12 @@ template element.
 Call `centaur-tabs-tab-label-function' to obtain a label for TAB."
   (let* ((buf (centaur-tabs-tab-value tab))
 	 (buf-file-name (buffer-file-name buf))
-	 (selected-p (centaur-tabs-selected-p tab (centaur-tabs-current-tabset)))
+	 (tabset (centaur-tabs-current-tabset))
+	 (selected-p (centaur-tabs-selected-p tab tabset))
 	 (not-read-only-p (with-current-buffer buf (not buffer-read-only)))
 	 (modified-p (and not-read-only-p (buffer-modified-p buf)))
 	 (use-mod-mark-p (and centaur-tabs-set-modified-marker modified-p))
+	 (current-buffer-index (cl-position tab (centaur-tabs-tabs tabset)))
 	 (mod-mark-face (if selected-p
 			    'centaur-tabs-modified-marker-selected
 			  'centaur-tabs-modified-marker-unselected))
@@ -678,6 +685,15 @@ Call `centaur-tabs-tab-label-function' to obtain a label for TAB."
       'pointer centaur-tabs-mouse-pointer
       'help-echo buf-file-name
       'local-map centaur-tabs-default-map)
+
+     (when centaur-tabs-show-tab-index
+       (propertize
+	(format centaur-tabs-index-format-str (+ current-buffer-index 1))
+	'face face
+	'pointer centaur-tabs-mouse-pointer
+	'centaur-tabs-tab tab
+	'help-echo buf-file-name
+	'local-map centaur-tabs-default-map))
 
      ;; close button and/or modified marker
      (if centaur-tabs-set-close-button


### PR DESCRIPTION
This adds the option to display a tab index. Makes jumping to tabs easier.
![Selection_001](https://user-images.githubusercontent.com/23086133/148620989-d108ca7c-e89a-4fb9-8534-e9c1b86445b6.png)

The indentation in `centaur-tabs-functions.el` is quite off. So let me know if something about that should be done.