### PR TITLE
Ensure that face-background reads indirect values

### DIFF
--- a/centaur-tabs-elements.el
+++ b/centaur-tabs-elements.el
@@ -121,7 +121,7 @@
   :type 'int)
 
 (defcustom centaur-tabs-background-color
-  (or (face-background 'centaur-tabs-default) (face-background 'default))
+  (face-background 'centaur-tabs-default nil 'default)
   "*Background color of the tab bar.
 By default, use the background color specified for the
 `centaur-tabs-default' face (or inherited from another face), or the
@@ -193,7 +193,7 @@ If icon gray out option enabled, gray out icon if not SELECTED."
 		   major-mode
 		   :v-adjust centaur-tabs-icon-v-adjust
 		   :height centaur-tabs-icon-scale-factor)))
-	       (background (face-background face))
+	       (background (face-background face nil 'default))
 	       (inactive (cond ((and (not selected)
 				     (eq centaur-tabs-gray-out-icons 'buffer))
 				(face-foreground 'mode-line-inactive))

--- a/centaur-tabs-functions.el
+++ b/centaur-tabs-functions.el
@@ -164,7 +164,7 @@ tab(B), move A to the left of B" t)
 
 (defun centaur-tabs-headline-match ()
   "Make headline use centaur-tabs-default-face."
-  (set-face-attribute centaur-tabs-display-line nil :background (face-background 'centaur-tabs-unselected)
+  (set-face-attribute centaur-tabs-display-line nil :background (face-background 'centaur-tabs-unselected nil 'default)
 		      :box nil
 		      :overline nil
 		      :underline nil))

--- a/centaur-tabs.el
+++ b/centaur-tabs.el
@@ -164,10 +164,10 @@ Run as `centaur-tabs-init-hook'."
   ;; If set, initialize selected overline
   (when (eq centaur-tabs-set-bar 'under)
     (set-face-attribute 'centaur-tabs-selected nil
-			:underline (face-background 'centaur-tabs-active-bar-face)
+			:underline (face-background 'centaur-tabs-active-bar-face nil 'default)
 			:overline nil)
     (set-face-attribute 'centaur-tabs-selected-modified nil
-			:underline (face-background 'centaur-tabs-active-bar-face)
+			:underline (face-background 'centaur-tabs-active-bar-face nil 'default)
 			:overline nil)
     (set-face-attribute 'centaur-tabs-unselected nil
 			:underline nil
@@ -177,10 +177,10 @@ Run as `centaur-tabs-init-hook'."
 			:overline nil))
   (when (eq centaur-tabs-set-bar 'over)
     (set-face-attribute 'centaur-tabs-selected nil
-			:overline (face-background 'centaur-tabs-active-bar-face)
+			:overline (face-background 'centaur-tabs-active-bar-face nil 'default)
 			:underline nil)
     (set-face-attribute 'centaur-tabs-selected-modified nil
-			:overline (face-background 'centaur-tabs-active-bar-face)
+			:overline (face-background 'centaur-tabs-active-bar-face nil 'default)
 			:underline nil)
     (set-face-attribute 'centaur-tabs-unselected nil
 			:overline nil


### PR DESCRIPTION
The old design would return an inappropriate nil value if the referenced face did not have an explicit background attribute.  This can happen if a theme uses ':inherit' instead of specifying the face attributes directly.

By declaring a fallback value, we make sure that such indirection will note return a nil value.

This is related to issue 178: <https://github.com/ema2159/centaur-tabs/issues/178>.