### PR TITLE
fix: Replace deprecated first for cl-first from cl-lib

### DIFF
--- a/centaur-tabs-interactive.el
+++ b/centaur-tabs-interactive.el
@@ -596,7 +596,7 @@ Modified copy of `treemacs-visit-node-in-external-application`."
 	(when action-is-command-p
 	  (call-interactively action))
 	(when (not action-is-command-p)
-	  (let* ((menu-key (first choice))
+	  (let* ((menu-key (cl-first choice))
 		 (choice-is-group-p (string= centaur-tabs--groups-submenu-key (symbol-name menu-key)))
 		 (name (car (last choice)))
 		 (name-as-string (symbol-name name)))


### PR DESCRIPTION
As described in #215, the `first` function from `cl.el` appears to be deprecated in favor of `cl-first` from `cl-lib.el` (this being a requirement of centaur-tabs).

This PR simply replaces a usage of `first` for `cl-first` to address an error when navigating the interactive menu.