### PR TITLE
fix: Allow quick navigation with (centaur-tabs-{backward,forward}--button)

### DIFF
--- a/centaur-tabs-functions.el
+++ b/centaur-tabs-functions.el
@@ -252,9 +252,6 @@ When not specified, ELLIPSIS defaults to ‘...’."
     ;;; Use right click to show the rest of groups
     (define-key map (vector centaur-tabs-display-line 'mouse-3) 'centaur-tabs--tab-menu )
 
-    ;;; Use double click to maximize window
-    (define-key map (vector centaur-tabs-display-line 'double-mouse-1) 'delete-other-windows)
-
     map)
   "Keymap to use in  Centaur-Tabs mode.")
 


### PR DESCRIPTION
## Summary

@jcs090218 I recently noticed that when clicking "too fast" on centaur-tabs-forward-button (resp. …-backward-…) several times, centaur-tabs only moves one tab at a time… which was quite distracting from a UX point of view.

This PR fixes this 🙂

## Remarks

* This patch is simpler than what I was expecting:
  Unbind (delete-other-windows) at [centaur-tabs-display-line double-mouse-1]

* This is not a loss in functionality, given:
  Function (delete-other-windows) is already bound at [mode-line mouse-2]