### PR TITLE
feat: Add dedicated `"Hidden"` buffer group (#239)

### DIFF
--- a/centaur-tabs-functions.el
+++ b/centaur-tabs-functions.el
@@ -75,6 +75,11 @@ name of this variable."
   :group 'centaur-tabs
   :type 'string)
 
+(defcustom centaur-tabs-hidden-group-name "Hidden"
+  "Group for hidden buffers (minibuffers)."
+  :group 'centaur-tabs
+  :type 'string)
+
 (defcustom centaur-tabs-label-fixed-length 0
   "Fixed length of label.  Set to 0 if dynamic."
   :group 'centaur-tabs
@@ -1335,6 +1340,8 @@ Other buffer group by `centaur-tabs-get-group-name' with project name."
                              magit-blob-mode
                              magit-blame-mode)))
      "Emacs")
+    ((string-prefix-p " *Mini" (buffer-name))
+     centaur-tabs-hidden-group-name)
     ((derived-mode-p 'shell-mode) "Shell")
     ((derived-mode-p 'eshell-mode) "EShell")
     ((derived-mode-p 'emacs-lisp-mode) "Elisp")

--- a/centaur-tabs-interactive.el
+++ b/centaur-tabs-interactive.el
@@ -421,7 +421,17 @@ Should be buffer local and speed up calculation of buffer groups.")
 
          (cond
           ((or (get-buffer-process (current-buffer)) (memq major-mode '(comint-mode compilation-mode))) '("Term"))
-          ((string-equal "*" (substring (buffer-name) 0 1)) '("Misc"))
+          ((or (string-equal "*" (substring (buffer-name) 0 1))
+               (memq major-mode '( magit-process-mode
+                             magit-status-mode
+                             magit-diff-mode
+                             magit-log-mode
+                             magit-file-mode
+                             magit-blob-mode
+                             magit-blame-mode)))
+           '("Misc"))
+          ((string-prefix-p " *Mini" (buffer-name))
+           `(,centaur-tabs-hidden-group-name))
           ((condition-case _err
                (projectile-project-root)
              (error nil))


### PR DESCRIPTION
This PR suggests modifying the default grouping functions. Fixes #238 and #239.

- Minibuffers are grouped into the new `"Hidden"` group so that they never show in the buffer bar.
- [`centaur-tabs-projectile-buffer-groups`](https://github.com/ema2159/centaur-tabs/blob/master/centaur-tabs-interactive.el#L416) is modified to have magit buffers in `Misc` group, not in the project group. It's just like `Emacs` group in [`centaur-tabs-buffer-groups`](https://github.com/ema2159/centaur-tabs/blob/38598c29061257963af91a6341deb09b2f1b8e1a/centaur-tabs-functions.el#L1318).
