### PR TITLE
Add centaur-tabs-icons-suffix

### DIFF
--- a/centaur-tabs-elements.el
+++ b/centaur-tabs-elements.el
@@ -231,6 +231,11 @@ the tab name."
   :group 'centaur-tabs
   :type 'string)
 
+(defcustom centaur-tabs-icons-suffix ""
+  "Suffix string after icons."
+  :group 'centaur-tabs
+  :type 'string)
+
 (defun centaur-tabs--icon-for-file (file &rest args)
   "Get the formatted icon for FILE.
 ARGS should be a plist containing `:height', `:v-adjust', or `:face' properties."

--- a/centaur-tabs-functions.el
+++ b/centaur-tabs-functions.el
@@ -744,7 +744,12 @@ Call `centaur-tabs-tab-label-function' to obtain a label for TAB."
                                   'centaur-tabs-tab tab
                                   'pointer centaur-tabs-mouse-pointer
                                   'local-map centaur-tabs-default-map)
-                      icon))
+                      icon
+                      (propertize centaur-tabs-icons-suffix
+                                  'face face
+                                  'centaur-tabs-tab tab
+                                  'pointer centaur-tabs-mouse-pointer
+                                  'local-map centaur-tabs-default-map)))
 
             ;; tab name
             (propertize (concat


### PR DESCRIPTION
On some screens the icon is too close to the tab label. This commit adds a centaur-tabs-icons-suffix to add ability to add some spaces. The default value is set to empty string to preserve backward compatibility.